### PR TITLE
Multifile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@degjs/form-mapper",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Get the values of form inputs as one collective object",
     "keywords": [
         "DEGJS",

--- a/src/formMapper.js
+++ b/src/formMapper.js
@@ -1,6 +1,7 @@
 const multiSelectSelector = 'select[multiple]';
 const radioSelector = 'input[type="radio"]';
 const checkboxSelector = 'input[type="checkbox"]';
+const fileSelector = 'input[type="file"]';
 const defaultElementSelectors = 'input, select, textarea';
 
 function getInputElements(formEl, selectorSettings = defaultElementSelectors) {
@@ -27,6 +28,8 @@ function mapValues(elementList) {
             returnVal[el.name] = [...el.options]
                                     .filter(optEl => optEl.selected)
                                     .map(opt => opt.value);
+        } else if (el.matches(fileSelector)) {
+            returnVal[el.name] = el.files;
         } else {
             returnVal[el.name] = el.value;
         }

--- a/src/formMapper.spec.js
+++ b/src/formMapper.spec.js
@@ -193,6 +193,23 @@ describe('map values', () => {
         expect(retVal).toEqual(comparisonVal);
     });
 
+    it('should handle file inputs', () => {
+        const comparisonVal = {
+            input1: ['1.jpg', '2.jpg']
+        };
+        const data = [
+            new File(["1"], "1.jpg"), new File(["2"], "2.jpg")
+        ];
+        document.body.innerHTML = `
+            <form>
+                <input type="file" multiple="multiple" />
+            </form>
+        `;
+        const formEl = document.querySelector('form');
+        const retVal = formMapper.getValues(formEl);
+        expect(retVal).toEqual(comparisonVal);
+    });
+
     it('should handle checkbox groups', () => {
         let comparisonVal = {
             input1: ['one', 'two']

--- a/src/formMapper.spec.js
+++ b/src/formMapper.spec.js
@@ -194,20 +194,14 @@ describe('map values', () => {
     });
 
     it('should handle file inputs', () => {
-        const comparisonVal = {
-            input1: ['1.jpg', '2.jpg']
-        };
-        const data = [
-            new File(["1"], "1.jpg"), new File(["2"], "2.jpg")
-        ];
         document.body.innerHTML = `
             <form>
-                <input type="file" multiple="multiple" />
+                <input name="input1" type="file" />
             </form>
         `;
         const formEl = document.querySelector('form');
         const retVal = formMapper.getValues(formEl);
-        expect(retVal).toEqual(comparisonVal);
+        expect(retVal).toBeInstanceOf(Object);
     });
 
     it('should handle checkbox groups', () => {

--- a/src/formMapper.spec.js
+++ b/src/formMapper.spec.js
@@ -201,7 +201,7 @@ describe('map values', () => {
         `;
         const formEl = document.querySelector('form');
         const retVal = formMapper.getValues(formEl);
-        expect(retVal).toBeInstanceOf(Object);
+        expect(retVal.input1).toBeInstanceOf(FileList);
     });
 
     it('should handle checkbox groups', () => {


### PR DESCRIPTION
Test is currently not working. I'm not sure how to give the file input a set of files as a value.
Basic idea of the change is that both single and multiple file inputs can return a fileList object which has a lot more information (and the other files, in multiple's case) than just getting the value of the input (file size, type, etc).  
