### PR TITLE
Ie11 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,4 @@ formMapper depends on the following browser APIs:
 
 As of Febrary 2018, matches is supported in IE9 and up.
 
-+Array.isArray: [Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) | [Polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill)
-
 To support legacy browsers, you'll need to include polyfills for the above APIs.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The getValues method returns an object with key value pairs being { inputName: i
 
 #### input
 Type: `Element | Element[]`
-The container element, input element or list of elements to get values from.
+The container element, input element or array of elements to get values from.
 
 #### opts
 Type: `Object`
@@ -69,5 +69,7 @@ formMapper depends on the following browser APIs:
 + matches: [Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) | [Polyfill](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill)
 
 As of Febrary 2018, matches is supported in IE9 and up.
+
++Array.isArray: [Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) | [Polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill)
 
 To support legacy browsers, you'll need to include polyfills for the above APIs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@degjs/form-mapper",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@degjs/form-mapper",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3282,7 +3282,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3303,12 +3304,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3323,17 +3326,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3450,7 +3456,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3462,6 +3469,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3476,6 +3484,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3483,12 +3492,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3507,6 +3518,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3587,7 +3599,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3599,6 +3612,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3684,7 +3698,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3720,6 +3735,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3739,6 +3755,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3782,12 +3799,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@degjs/form-mapper",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "description": "Get the values of form inputs as one collective object",
     "keywords": [
         "DEGJS",

--- a/src/formMapper.js
+++ b/src/formMapper.js
@@ -13,10 +13,13 @@ export function getInputElements(formEl, selectorSettings = defaultElementSelect
 }
 
 function mapValues(elementList) {
-    const returnVal = {};
-    for (const el of elementList) {
+    if(!Array.isArray(elementList)) {
+        return {};
+    }
+
+    return elementList.reduce((returnVal, el) => {
         if (!el.name) {
-            continue;
+            return returnVal;
         }
 
         if (el.matches(checkboxSelector)) {
@@ -37,8 +40,8 @@ function mapValues(elementList) {
         } else {
             returnVal[el.name] = el.value;
         }
-    }
-    return returnVal;
+        return returnVal;
+    }, {});
 }
 
 /**


### PR DESCRIPTION
The for..of syntax in the mapValues() function was causing a couple of problems:

- Babel transpiles for..of into a Symbol iterator, which requires a couple of Symbol polyfills that wasn't mentioned in the README
- Even with those Symbol polyfills, IE11 was still throwing a strange error related to the iterator in certain circumstances.

The easiest fix was to swap out the for..of for an Array.reduce.